### PR TITLE
Remove Twitter link from landing page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,9 +26,6 @@
                     <!-- </li>
                     <li> -->
                         <a href="http://ca.linkedin.com/in/zafaraliahmed"><i class="fa fa-linkedin-square"></i></a>
-                    <!-- </li>
-                    <li> -->
-                        <a href="http://www.twitter.com/zafarali"><i class="fa fa-twitter-square"></i></a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
The user requested the removal of the Twitter link from the landing page. I identified the link in `_includes/header.html` and removed the corresponding anchor tag and its list item structure. I verified the change by reading the file and searching for any remaining occurrences of "twitter" in the codebase.

---
*PR created automatically by Jules for task [14055670428497989962](https://jules.google.com/task/14055670428497989962) started by @zafarali*